### PR TITLE
Change versions of tailwindcss, autoprefixer and postcss

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ const json = `{
 }
 `
 
-const commands = 'npm i -D @fullhuman/postcss-purgecss autoprefixer parcel-bundler postcss tailwindcss'
+const commands = 'npm i -D @fullhuman/postcss-purgecss autoprefixer@^9 parcel-bundler postcss@^7 tailwindcss@compat'
 
 function dependencies() {
   console.log('📦  Installing dependencies from NPM... this will take a bit.');

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ const json = `{
 }
 `
 
-const commands = 'npm i -D @fullhuman/postcss-purgecss autoprefixer@^9 parcel-bundler postcss@^7 tailwindcss@compat'
+const commands = 'npm i -D @fullhuman/postcss-purgecss autoprefixer@^9 parcel-bundler postcss@^7 tailwindcss@npm:@tailwindcss/postcss7-compat'
 
 function dependencies() {
   console.log('📦  Installing dependencies from NPM... this will take a bit.');


### PR DESCRIPTION
Hi,

I changed the versions of tailwindcss, autoprefixer and postcss packages for mantain compatibility between Tailwindcss 2.0 and Parcel, cause it require PostCCS version 7. See this https://tailwindcss.com/docs/installation#post-css-7-compatibility-build

This fix #5 